### PR TITLE
Add tool filtering in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ The JSON file should follow this structure:
       "args": [
         "mcp-server-fetch"
       ],
-      "transportType": "stdio"
+      "transportType": "stdio",
+      "tools": ["fetch"]
     },
     "github": {
       "timeout": 60,
@@ -383,7 +384,8 @@ Examples:
       "args": [
         "mcp-server-fetch"
       ],
-      "transportType": "stdio"
+      "transportType": "stdio",
+      "tools": ["fetch"]
     },
     "github": {
       "timeout": 60,

--- a/config_example.json
+++ b/config_example.json
@@ -7,7 +7,8 @@
       "args": [
         "mcp-server-fetch"
       ],
-      "transportType": "stdio"
+      "transportType": "stdio",
+      "tools": ["fetch"]
     },
     "github": {
       "enabled": false,

--- a/src/mcp_proxy/__init__.py
+++ b/src/mcp_proxy/__init__.py
@@ -1,1 +1,5 @@
 """Library for proxying MCP servers across different transports."""
+
+from .server_config import ServerConfig
+
+__all__ = ["ServerConfig"]

--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -12,7 +12,11 @@ from mcp.client.session import ClientSession
 logger = logging.getLogger(__name__)
 
 
-async def create_proxy_server(remote_app: ClientSession) -> server.Server[object]:  # noqa: C901, PLR0915
+async def create_proxy_server(
+    remote_app: ClientSession,
+    *,
+    allowed_tools: list[str] | None = None,
+) -> server.Server[object]:  # noqa: C901, PLR0915
     """Create a server instance from a remote app."""
     logger.debug("Sending initialization request to remote MCP server...")
     response = await remote_app.initialize()
@@ -86,11 +90,25 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
 
         async def _list_tools(_: t.Any) -> types.ServerResult:  # noqa: ANN401
             tools = await remote_app.list_tools()
+            if allowed_tools is not None:
+                tools = [t for t in tools if t.name in allowed_tools]
             return types.ServerResult(tools)
 
         app.request_handlers[types.ListToolsRequest] = _list_tools
 
         async def _call_tool(req: types.CallToolRequest) -> types.ServerResult:
+            if allowed_tools is not None and req.params.name not in allowed_tools:
+                return types.ServerResult(
+                    types.CallToolResult(
+                        content=[
+                            types.TextContent(
+                                type="text",
+                                text="Tool not allowed",
+                            ),
+                        ],
+                        isError=True,
+                    ),
+                )
             try:
                 result = await remote_app.call_tool(
                     req.params.name,

--- a/src/mcp_proxy/server_config.py
+++ b/src/mcp_proxy/server_config.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from mcp.client.stdio import StdioServerParameters
+
+
+@dataclass
+class ServerConfig:
+    """Configuration for a proxied server."""
+
+    stdio_params: StdioServerParameters
+    tools: list[str] | None = None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -276,7 +276,10 @@ async def test_run_mcp_server_with_default_server(
 
         # Verify calls
         mock_stdio_client.assert_called_once_with(mock_stdio_params.stdio_params)
-        mock_create_proxy.assert_called_once_with(mock_session)
+        mock_create_proxy.assert_called_once_with(
+            mock_session,
+            allowed_tools=mock_stdio_params.tools,
+        )
         mock_create_routes.assert_called_once_with(
             mock_proxy,
             stateless_instance=mock_settings.stateless,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,6 +11,8 @@ import uvicorn
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters
+
+from mcp_proxy import ServerConfig
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.server import FastMCP, Server
 from mcp.types import TextContent
@@ -184,13 +186,15 @@ def mock_settings() -> MCPServerSettings:
 
 
 @pytest.fixture
-def mock_stdio_params() -> StdioServerParameters:
-    """Create mock stdio server parameters for testing."""
-    return StdioServerParameters(
-        command="echo",
-        args=["hello"],
-        env={"TEST_VAR": "test_value"},
-        cwd="/tmp",  # noqa: S108
+def mock_stdio_params() -> ServerConfig:
+    """Create mock server configuration for testing."""
+    return ServerConfig(
+        stdio_params=StdioServerParameters(
+            command="echo",
+            args=["hello"],
+            env={"TEST_VAR": "test_value"},
+            cwd="/tmp",  # noqa: S108
+        ),
     )
 
 
@@ -242,7 +246,7 @@ async def test_run_mcp_server_no_servers_configured(mock_settings: MCPServerSett
 
 async def test_run_mcp_server_with_default_server(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server with a default server configuration."""
     with (
@@ -271,7 +275,7 @@ async def test_run_mcp_server_with_default_server(
         await run_mcp_server(mock_settings, mock_stdio_params, {})
 
         # Verify calls
-        mock_stdio_client.assert_called_once_with(mock_stdio_params)
+        mock_stdio_client.assert_called_once_with(mock_stdio_params.stdio_params)
         mock_create_proxy.assert_called_once_with(mock_session)
         mock_create_routes.assert_called_once_with(
             mock_proxy,
@@ -279,24 +283,26 @@ async def test_run_mcp_server_with_default_server(
         )
         mock_logger.info.assert_any_call(
             "Setting up default server: %s %s",
-            mock_stdio_params.command,
-            " ".join(mock_stdio_params.args),
+            mock_stdio_params.stdio_params.command,
+            " ".join(mock_stdio_params.stdio_params.args),
         )
         mock_server_instance.serve.assert_called_once()
 
 
 async def test_run_mcp_server_with_named_servers(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server with named servers configuration."""
     named_servers = {
         "server1": mock_stdio_params,
-        "server2": StdioServerParameters(
-            command="python",
-            args=["-m", "mcp_server"],
-            env={"PYTHON_PATH": "/usr/bin/python"},
-            cwd="/home/user",
+        "server2": ServerConfig(
+            stdio_params=StdioServerParameters(
+                command="python",
+                args=["-m", "mcp_server"],
+                env={"PYTHON_PATH": "/usr/bin/python"},
+                cwd="/home/user",
+            ),
         ),
     }
 
@@ -334,8 +340,8 @@ async def test_run_mcp_server_with_named_servers(
         mock_logger.info.assert_any_call(
             "Setting up named server '%s': %s %s",
             "server1",
-            mock_stdio_params.command,
-            " ".join(mock_stdio_params.args),
+            mock_stdio_params.stdio_params.command,
+            " ".join(mock_stdio_params.stdio_params.args),
         )
         mock_logger.info.assert_any_call(
             "Setting up named server '%s': %s %s",
@@ -348,7 +354,7 @@ async def test_run_mcp_server_with_named_servers(
 
 
 async def test_run_mcp_server_with_cors_middleware(
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server adds CORS middleware when allow_origins is set."""
     settings_with_cors = MCPServerSettings(
@@ -392,7 +398,7 @@ async def test_run_mcp_server_with_cors_middleware(
 
 
 async def test_run_mcp_server_debug_mode(
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server with debug mode enabled."""
     debug_settings = MCPServerSettings(
@@ -433,7 +439,7 @@ async def test_run_mcp_server_debug_mode(
 
 
 async def test_run_mcp_server_stateless_mode(
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server with stateless mode enabled."""
     stateless_settings = MCPServerSettings(
@@ -475,7 +481,7 @@ async def test_run_mcp_server_stateless_mode(
 
 async def test_run_mcp_server_uvicorn_config(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server creates correct uvicorn configuration."""
     with (
@@ -517,7 +523,7 @@ async def test_run_mcp_server_uvicorn_config(
 
 async def test_run_mcp_server_global_status_updates(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server updates global status correctly."""
     from mcp_proxy.mcp_server import _global_status
@@ -560,7 +566,7 @@ async def test_run_mcp_server_global_status_updates(
 
 async def test_run_mcp_server_sse_url_logging(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server logs correct SSE URLs."""
     named_servers = {"test_server": mock_stdio_params}
@@ -603,7 +609,7 @@ async def test_run_mcp_server_sse_url_logging(
 
 async def test_run_mcp_server_exception_handling(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server handles exceptions properly."""
     with (
@@ -623,7 +629,7 @@ async def test_run_mcp_server_exception_handling(
 
 async def test_run_mcp_server_both_default_and_named_servers(
     mock_settings: MCPServerSettings,
-    mock_stdio_params: StdioServerParameters,
+    mock_stdio_params: ServerConfig,
 ) -> None:
     """Test run_mcp_server with both default and named servers."""
     named_servers = {"named_server": mock_stdio_params}
@@ -661,14 +667,14 @@ async def test_run_mcp_server_both_default_and_named_servers(
         # Verify logging for both servers
         mock_logger.info.assert_any_call(
             "Setting up default server: %s %s",
-            mock_stdio_params.command,
-            " ".join(mock_stdio_params.args),
+            mock_stdio_params.stdio_params.command,
+            " ".join(mock_stdio_params.stdio_params.args),
         )
         mock_logger.info.assert_any_call(
             "Setting up named server '%s': %s %s",
             "named_server",
-            mock_stdio_params.command,
-            " ".join(mock_stdio_params.args),
+            mock_stdio_params.stdio_params.command,
+            " ".join(mock_stdio_params.stdio_params.args),
         )
 
         mock_server_instance.serve.assert_called_once()


### PR DESCRIPTION
## Summary
- introduce `ServerConfig` dataclass for named servers
- extend config loader to parse `tools` list
- filter tools in `create_proxy_server`
- support new ServerConfig throughout CLI and server
- document tools field in README and example config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6840cba0a0d8832490d8007a60ca1788